### PR TITLE
Update init.php

### DIFF
--- a/inc/classes/custom-metaboxes/init.php
+++ b/inc/classes/custom-metaboxes/init.php
@@ -752,7 +752,7 @@ class cmb_Meta_Box {
 		elseif ( is_string( $meta_box['pages'] ) )
 			$type = $meta_box['pages'];
 		// if it's an array of one, extract it
-		elseif ( is_array( $meta_box['pages'] ) && count( $meta_box['pages'] === 1 ) )
+		elseif ( is_array( $meta_box['pages'] ) && ( count( $meta_box['pages'] ) === 1 ) )
 			$type = is_string( end( $meta_box['pages'] ) ) ? end( $meta_box['pages'] ) : false;
 
 		if ( !$type )


### PR DESCRIPTION
Fix to this error:
TypeError: count(): Argument #1 ($value) must be of type Countable|array, bool given in /wp-content/themes/wpex-zero/inc/classes/custom-metaboxes/init.php:755
This error makes the wp-admin panel crash before you even get to the login-page.

https://www.php.net/manual/en/function.count.php:
Changelog 
Version	Description
8.0.0	count() will now throw TypeError on invalid countable types passed to the value parameter.
7.2.0	count() will now yield a warning on invalid countable types passed to the value parameter.